### PR TITLE
Open proof namespace and support `distinct`.

### DIFF
--- a/src/proof/lean/lean_printer.cpp
+++ b/src/proof/lean/lean_printer.cpp
@@ -377,7 +377,8 @@ void LeanPrinter::print(std::ostream& out, std::shared_ptr<ProofNode> pfn)
     Trace("test-lean-pf") << ss.str() << "\n";
   }
   // Print preamble
-  out << "import Smt.Reconstruction.Certifying\n\nopen Classical\n\n";
+  out << "import Smt.Reconstruction.Certifying\n\nopen Classical\nopen "
+         "Smt.Reconstruction.Certifying\n\n";
   // increase recursion depth and heartbeats
   out << "\n\nset_option maxRecDepth 10000\nset_option maxHeartbeats 500000\n\n";
 


### PR DESCRIPTION
Added a namespace for proofs to avoid naming conflicts with Mathlib.