### PR TITLE
Fixing congruence over addition

### DIFF
--- a/src/proof/lean/lean_post_processor.cpp
+++ b/src/proof/lean/lean_post_processor.cpp
@@ -845,10 +845,10 @@ bool LeanProofPostprocessCallback::update(Node res,
             }
             else
             {
-              Node a1 = nm->mkNode(kind::SEXPR, op, children[j][0], currEq[0]);
-              Node a2 = nm->mkNode(kind::SEXPR, op, children[j][1], currEq[1]);
-              Node nxtEq = nm->mkNode(kind::SEXPR, eqNode, a1, a2);
-              addLeanStep(currEq,
+              Node add1 = nm->mkNode(kind::SEXPR, op, children[j][0], currEq[0]);
+              Node add2 = nm->mkNode(kind::SEXPR, op, children[j][1], currEq[1]);
+              Node nxtEq = nm->mkNode(kind::SEXPR, eqNode, add1, add2);
+              addLeanStep(nxtEq,
                           LeanRule::CONG_ADD,
                           d_empty,
                           {children[j], currEq},

--- a/src/proof/lean/lean_post_processor.cpp
+++ b/src/proof/lean/lean_post_processor.cpp
@@ -824,7 +824,7 @@ bool LeanProofPostprocessCallback::update(Node res,
                                       children[nchildren - 1][1]);
           Node currEq = nm->mkNode(kind::SEXPR, eqNode, addLefts, addRights);
           addLeanStep(currEq,
-                      LeanRule::CONG_ADD,
+                      LeanRule::CONG_ADD_PARTIAL,
                       d_empty,
                       {children[nchildren - 2], children[nchildren - 1]},
                       {},
@@ -849,7 +849,7 @@ bool LeanProofPostprocessCallback::update(Node res,
               Node add2 = nm->mkNode(kind::SEXPR, op, children[j][1], currEq[1]);
               Node nxtEq = nm->mkNode(kind::SEXPR, eqNode, add1, add2);
               addLeanStep(nxtEq,
-                          LeanRule::CONG_ADD,
+                          LeanRule::CONG_ADD_PARTIAL,
                           d_empty,
                           {children[j], currEq},
                           {},

--- a/src/proof/lean/lean_printer.cpp
+++ b/src/proof/lean/lean_printer.cpp
@@ -79,6 +79,7 @@ LeanPrinter::LeanPrinter(Env& env, LeanNodeConverter& lnc)
                   LeanRule::R1_PARTIAL,
                   LeanRule::CONG_PARTIAL,
                   LeanRule::CONG_ARG_PARTIAL,
+                  LeanRule::CONG_ADD,
                   LeanRule::BIND_PARTIAL,
                   LeanRule::BIND_LAMBDA_PARTIAL,
                   LeanRule::TRANS_PARTIAL,

--- a/src/proof/lean/lean_printer.cpp
+++ b/src/proof/lean/lean_printer.cpp
@@ -79,7 +79,7 @@ LeanPrinter::LeanPrinter(Env& env, LeanNodeConverter& lnc)
                   LeanRule::R1_PARTIAL,
                   LeanRule::CONG_PARTIAL,
                   LeanRule::CONG_ARG_PARTIAL,
-                  LeanRule::CONG_ADD,
+                  LeanRule::CONG_ADD_PARTIAL,
                   LeanRule::BIND_PARTIAL,
                   LeanRule::BIND_LAMBDA_PARTIAL,
                   LeanRule::TRANS_PARTIAL,

--- a/src/proof/lean/lean_rules.cpp
+++ b/src/proof/lean/lean_rules.cpp
@@ -89,6 +89,7 @@ const char* toString(LeanRule id)
     case LeanRule::CONG_ARG: return "flipCongrArg";
     case LeanRule::CONG_ARG_PARTIAL: return "flipCongrArg";
     case LeanRule::CONG_ITE: return "congrIte";
+    case LeanRule::CONG_ADD: return "congrHAdd";
     case LeanRule::REFL: return "rfl";
     case LeanRule::TRANS: return "Eq.trans";
     case LeanRule::TRANS_PARTIAL: return "Eq.trans";

--- a/src/proof/lean/lean_rules.cpp
+++ b/src/proof/lean/lean_rules.cpp
@@ -90,6 +90,7 @@ const char* toString(LeanRule id)
     case LeanRule::CONG_ARG_PARTIAL: return "flipCongrArg";
     case LeanRule::CONG_ITE: return "congrIte";
     case LeanRule::CONG_ADD: return "congrHAdd";
+    case LeanRule::CONG_ADD_PARTIAL: return "congrHAdd";
     case LeanRule::REFL: return "rfl";
     case LeanRule::TRANS: return "Eq.trans";
     case LeanRule::TRANS_PARTIAL: return "Eq.trans";

--- a/src/proof/lean/lean_rules.h
+++ b/src/proof/lean/lean_rules.h
@@ -91,6 +91,7 @@ enum class LeanRule : uint32_t
   CONG_ARG_PARTIAL,
   CONG_ITE,
   CONG_ADD,
+  CONG_ADD_PARTIAL,
   REFL,
   TRANS,
   TRANS_PARTIAL,

--- a/src/proof/lean/lean_rules.h
+++ b/src/proof/lean/lean_rules.h
@@ -91,7 +91,6 @@ enum class LeanRule : uint32_t
   CONG_ARG_PARTIAL,
   CONG_ITE,
   CONG_ADD,
-  CONG_OP,
   REFL,
   TRANS,
   TRANS_PARTIAL,

--- a/src/proof/lean/lean_rules.h
+++ b/src/proof/lean/lean_rules.h
@@ -90,6 +90,8 @@ enum class LeanRule : uint32_t
   CONG_ARG,
   CONG_ARG_PARTIAL,
   CONG_ITE,
+  CONG_ADD,
+  CONG_OP,
   REFL,
   TRANS,
   TRANS_PARTIAL,


### PR DESCRIPTION
Adds a patch in the function ```LeanProofPostprocessCallback::update``` to avoid getting Lean's typeclass resolution algorithm stuck when trying to prove ```Eq HAdd.hAdd HAdd.hAdd```. This is done by not using ```congr``` to prove congruence over addition, but a new function named ```congrHAdd``` that restricts the original ```congr``` by fixing the operation to be ```HAdd```. Also, all partial applications of congruence over addition are removed, since they would also make the typeclass resolution algorithm stuck.

Two points that may need improvement in this PR:

1. We probably will have the same issue with multiplication and other operations... maybe this could be handled already in this PR.
2. The original behavior was to print the type of the original conclusion in the last step performed by a ```congr``` rule. Now, since ```CONG_ADD``` is a letRule, we just print the last step with a let, without the type.