### PR TITLE
Fix bug in drat(t) proof generation

### DIFF
--- a/src/prop/proof_cnf_stream.cpp
+++ b/src/prop/proof_cnf_stream.cpp
@@ -1017,11 +1017,12 @@ SatLiteral ProofCnfStream::handleOr(TNode node)
   added = d_cnfStream.assertClause(node.negate(), clause);
   if (added)
   {
-    std::vector<Node> disjuncts{node.notNode()};
+    std::vector<Node> disjuncts;
     for (unsigned i = 0; i < size; ++i)
     {
       disjuncts.push_back(node[i]);
     }
+    disjuncts.push_back(node.notNode());
     Node clauseNode = nm->mkNode(kind::OR, disjuncts);
     d_proof.addStep(clauseNode, PfRule::CNF_OR_POS, {}, {node});
     Trace("cnf") << "ProofCnfStream::handleOr: CNF_OR_POS added " << clauseNode


### PR DESCRIPTION
If literal corresponding to node is added last to the clause then also node needs to be added last to clauseNode.